### PR TITLE
Bytecode/Unicode Fix

### DIFF
--- a/django_bouncy/utils.py
+++ b/django_bouncy/utils.py
@@ -27,6 +27,7 @@ from django.conf import settings
 from django.core.cache import get_cache
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.utils import timezone
+from django.utils.encoding import smart_str
 import dateutil.parser
 
 from django_bouncy import signals
@@ -78,7 +79,7 @@ def grab_keyfile(cert_url):
         pemfile = response.read()
         # Extract the first certificate in the file and confirm it's a valid
         # PEM certificate
-        certificates = pem.parse(pemfile)
+        certificates = pem.parse(smart_str(pemfile))
 
         # A proper certificate file will contain 1 certificate
         if len(certificates) != 1:


### PR DESCRIPTION
In Python 3.4, Django 1.7, I get a TypeError when utils.grab_keyfile attempts to parse the key file (line 82).
This should be a backwards compatible fix.