### PR TITLE
Updating travis, removing `setup.py test`, bumping version to 0.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: python
-# Test against 2.6, 2.7, 3.2 and 3.3
+# Test against 2.7, 3.2 and 3.3
 # We don't support 3.2 because the pem library doesn't support it, but PEM
 # could change in the future so it's still worth testing against
 python:
-  - "2.6"
   - "2.7"
   - "3.2"
   - "3.3"
@@ -12,38 +11,24 @@ python:
 # command to define we should test against the latest version of all supported
 # versions of django (1.4.*, 1.5.*, 1.6.*)
 env:
-  - DJANGO_INSTALL=django\<1.4.99
-  - DJANGO_INSTALL=django\<1.5.99
-  - DJANGO_INSTALL=django\<1.6.99
   - DJANGO_INSTALL=django\<1.7.99
+  - DJANGO_INSTALL=django\<1.8.99
   - DJANGO_INSTALL=git+https://github.com/django/django.git\#egg=django
 # command to install dependencies (mock & nose are already installed)
 install:
   - pip install $DJANGO_INSTALL
+  - python setup.py install
+  - pip install django-nose coverage mock
 # command to run tests
-script: python setup.py test
+script: python manage.py test --settings 'test_settings'
 matrix:
   fast_finish: true
   exclude:
-    # Django doesn't support following combinations
-    - python: "2.6"
-      env: DJANGO_INSTALL=django\<1.7.99
-    - python: "3.2"
-      env: DJANGO_INSTALL=django\<1.4.99
     - python: "3.3"
       env: DJANGO_INSTALL=django\<1.4.99
     - python: "3.4"
       env: DJANGO_INSTALL=django\<1.4.99
   allow_failures:
-    # Python 3 in Django 1.5.* was not production-ready, but still supported
-    # so we should still test against it but not fail the build if there are
-    # any issues
-    - python: "3.2"
-      env: MAX_DJANGO_VERSION=1.5.99
-    - python: "3.3"
-      env: MAX_DJANGO_VERSION=1.5.99
-    - python: "3.4"
-      env: MAX_DJANGO_VERSION=1.5.99
 
     # pypy testing support is experimental
     - python: "pypy"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,13 @@
 language: python
 # Test against 2.7, 3.2 and 3.3
-# We don't support 3.2 because the pem library doesn't support it, but PEM
-# could change in the future so it's still worth testing against
+# We don't support 3.2 because the pem library doesn't support it
 python:
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
   - "pypy"
 # command to define we should test against the latest version of all supported
-# versions of django (1.4.*, 1.5.*, 1.6.*)
+# versions of django (1.7.x, 1.8.x)
 env:
   - DJANGO_INSTALL=django\<1.7.99
   - DJANGO_INSTALL=django\<1.8.99
@@ -29,14 +27,8 @@ matrix:
     - python: "3.4"
       env: DJANGO_INSTALL=django\<1.4.99
   allow_failures:
-
     # pypy testing support is experimental
     - python: "pypy"
-
-    # Python 3.2 tends to not work due to PEM library issues
-    # But maybe someday the library will be fixed, so lets test against it
-    # anyways, but not fail the entire build if there is an issue
-    - python: "3.2"
 
     # Tests against the master branch may break
     - env: DJANGO_INSTALL=git+https://github.com/django/django.git\#egg=django

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,6 @@
 #!/usr/bin/env python
 
-try:
-    from setuptools import setup
-except ImportError:
-    from ez_setup import use_setuptools
-    use_setuptools()
-    from setuptools import setup
+from setuptools import setup
 
 import os
 # import sys
@@ -15,7 +10,7 @@ ROOT = os.path.abspath(os.path.dirname(__file__))
 
 setup(
     name='django-bouncy',
-    version='0.0.1',
+    version='0.1.0',
     author='Nick Catalano',
     packages=['django_bouncy', 'django_bouncy.migrations', 'django_bouncy.tests'],
     url='https://github.com/ofa/django-bouncy',
@@ -27,17 +22,12 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'Django>=1.4',
+        'Django>=1.7',
         'python-dateutil>=2.1',
         'pyopenssl>=0.13.1',
-        'pem>=0.1.0'
+        'pem>=0.1.0',
+        'twisted'
     ],
-    tests_require=[
-        'nose>=1.3',
-        'django-setuptest>=0.1.4',
-        'mock'
-    ],
-    test_suite='setuptest.setuptest.SetupTestSuite',
     keywords="aws ses sns seacucumber boto",
     classifiers=['Development Status :: 4 - Beta', 'Intended Audience :: Developers', 'Topic :: Internet :: WWW/HTTP']
 )

--- a/test_settings.py
+++ b/test_settings.py
@@ -1,5 +1,7 @@
 DATABASE_ENGINE = 'sqlite3'
 
+SECRET_KEY = 'abcd123'
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',


### PR DESCRIPTION
This modifies travis to no longer try to use `python setup.py test` (it won't work anymore)
We also bump the version of the package to 0.1.0 for python-package-index convenience

Closes #4 
Closes #8