### PR TITLE
Remove twisted as a dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ mock
 pyopenssl>=0.13.1
 pem>=0.1.0
 python-dateutil
-twisted

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
         'python-dateutil>=2.1',
         'pyopenssl>=0.13.1',
         'pem>=0.1.0',
-        'twisted'
     ],
     keywords="aws ses sns seacucumber boto",
     classifiers=['Development Status :: 4 - Beta', 'Intended Audience :: Developers', 'Topic :: Internet :: WWW/HTTP']


### PR DESCRIPTION
I can't figure out why twisted is listed as a dependency.  Let's remove it?