### PR TITLE
Fixed Python3 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,11 @@ python:
   - "3.5"
   - "pypy"
 # command to define we should test against the latest version of all supported
-# versions of django (1.8.x, 1.9.x)
+# versions of django (1.8.x, 1.9.x, 1.10.x)
 env:
   - DJANGO_INSTALL=django\<1.8.99
   - DJANGO_INSTALL=django\<1.9.99
+  - DJANGO_INSTALL=django\<1.10.99
   - DJANGO_INSTALL=git+https://github.com/django/django.git\#egg=django
 # command to install dependencies (mock & nose are already installed)
 install:
@@ -33,7 +34,11 @@ matrix:
     - python: "3.3"
       env: DJANGO_INSTALL=django\<1.9.99
 
-    # Django 1.9 onward doesn't support Python 3.3
+    # Django 1.10 onward doesn't support Python 3.3
+    - python: "3.3"
+      env: DJANGO_INSTALL=django\<1.10.99
+
+    # Django latest onward doesn't support Python 3.3
     - python: "3.3"
       env: DJANGO_INSTALL=git+https://github.com/django/django.git\#egg=django
 # turn off email notifications

--- a/django_bouncy/utils.py
+++ b/django_bouncy/utils.py
@@ -27,7 +27,7 @@ from django.conf import settings
 from django.core.cache import caches
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.utils import timezone
-from django.utils.encoding import smart_str
+from django.utils.encoding import smart_bytes
 import dateutil.parser
 
 from django_bouncy import signals
@@ -79,7 +79,7 @@ def grab_keyfile(cert_url):
         pemfile = response.read()
         # Extract the first certificate in the file and confirm it's a valid
         # PEM certificate
-        certificates = pem.parse(smart_str(pemfile))
+        certificates = pem.parse(smart_bytes(pemfile))
 
         # A proper certificate file will contain 1 certificate
         if len(certificates) != 1:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py35,py27}-django{18,19}
+envlist = {py35,py27}-django{18,19,110}
 [testenv]
 basepython =
     py35: python3.5
@@ -7,6 +7,7 @@ basepython =
 deps =
     django18: django<1.8.99
     django19: django<1.9.99
+    django110: django<1.10.99
     nose
     django-nose
     coverage


### PR DESCRIPTION
django-bouncy authors.

First, thanks for the awesome tool.
I encountered errors such as the following.

```
(django-bouncy) tell-k-no-MacBook-Pro:django-bouncy tell_k$ tox -e py35-django18
EE....
======================================================================
ERROR: Test a non-valid keyfile
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/tell_k/Work/github.com/tell-k/django-bouncy/.tox/py35-django18/lib/python3.5/site-packages/mock/mock.py", line 1305, in patched
    return func(*args, **keywargs)
  File "/Users/tell_k/Work/github.com/tell-k/django-bouncy/django_bouncy/tests/utils.py", line 36, in test_bad_keyfile
    utils.grab_keyfile('http://www.fakeurl.com')
  File "/Users/tell_k/Work/github.com/tell-k/django-bouncy/django_bouncy/utils.py", line 82, in grab_keyfile
    certificates = pem.parse(smart_str(pemfile))
  File "/Users/tell_k/Work/github.com/tell-k/django-bouncy/.tox/py35-django18/lib/python3.5/site-packages/pem/_core.py", line 104, in parse
    for match in _PEM_RE.finditer(pem_str)]
TypeError: cannot use a bytes pattern on a string-like object

======================================================================
ERROR: Test the grab_keyfile plugin
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/tell_k/Work/github.com/tell-k/django-bouncy/.tox/py35-django18/lib/python3.5/site-packages/mock/mock.py", line 1305, in patched
    return func(*args, **keywargs)
  File "/Users/tell_k/Work/github.com/tell-k/django-bouncy/django_bouncy/tests/utils.py", line 23, in test_grab_keyfile
    result = utils.grab_keyfile('http://www.fakeurl.com')
  File "/Users/tell_k/Work/github.com/tell-k/django-bouncy/django_bouncy/utils.py", line 82, in grab_keyfile
    certificates = pem.parse(smart_str(pemfile))
  File "/Users/tell_k/Work/github.com/tell-k/django-bouncy/.tox/py35-django18/lib/python3.5/site-packages/pem/_core.py", line 104, in parse
    for match in _PEM_RE.finditer(pem_str)]
TypeError: cannot use a bytes pattern on a string-like object

----------------------------------------------------------------------
Ran 35 tests in 0.109s

FAILED (errors=2)
```

The cause of this error is because `django.utils.smart_str` cannot return bytes when using python3.
You should use `django.utils.smart_bytes` when supporting python2 and python3.

see also https://docs.djangoproject.com/en/1.10/ref/utils/#django.utils.encoding.smart_str

In addition, I updated tox.ini and .travis.yml so that I can also test it with Django 1.10 :)
thx.